### PR TITLE
Avoid error specifier-qualifier-list on 2.6.18 kernels

### DIFF
--- a/hypervm/development-create-binaries.sh
+++ b/hypervm/development-create-binaries.sh
@@ -26,7 +26,7 @@ echo "### Start compiling"
 # Compile C files
 # Part 1
 cd src/
-make ; make install
+make all; make install
 cd ../
 echo "### Finished"
 echo "################################"

--- a/hypervm/make-distribution.sh
+++ b/hypervm/make-distribution.sh
@@ -44,7 +44,7 @@ rm -f hypervm-$version.zip
 echo "### Compile c files..."
 # Compile C files
 cd src
-make ; make install
+make all; make install
 cd ../
 #
 echo "### Create zip package..."

--- a/hypervm/src/Makefile
+++ b/hypervm/src/Makefile
@@ -21,7 +21,12 @@ PREFIX=lx
 LIBS=-I/usr/include -lssl
 CC=gcc
 DEBUG = -g
-CFLAGS = -Wall -ansi -pedantic -Wextra -Werror  $(DEBUG)
+CFLAGS = -Wall -O2 -std=c99 -ansi -pedantic -Wextra -Werror -Wunused \
+-Wimplicit -Wshadow -Wformat=2 -Wmissing-declarations   \
+-Wno-missing-prototypes -Wwrite-strings                 \
+-Wbad-function-cast -Wnested-externs -Wcomment -Winline \
+-Wchar-subscripts -Wcast-align -Wno-format-nonliteral   \
+-Wsequence-point -Wdeclaration-after-statement $(DEBUG)
 LFLAGS = -Wall -c $(DEBUG)
 
 xen:

--- a/hypervm/src/losetup.c
+++ b/hypervm/src/losetup.c
@@ -27,7 +27,7 @@ int find_unused_loop_device(char **ret)
 	   So, we just try /dev/loop[0-7]. */
 
 	char dev[20];
-	char *loop_formats[] = { "/dev/loop%d", "/dev/loop/%d" };
+	const char *loop_formats[] = { "/dev/loop%d", "/dev/loop/%d" };
 	int i, j, fd, somedev = 0, someloop = 0; /* loop_known = 0 unused */
 	struct stat statbuf;
 	struct loop_info loopinfo;

--- a/hypervm/src/losetup.h
+++ b/hypervm/src/losetup.h
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <ctype.h>
 #include <fcntl.h>
 #include <errno.h>
@@ -29,7 +30,10 @@
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
-#define dev_t int
+
+/* Avoid error "specifier-qualifier-list" on 2.6.18 kernels (Centos) */
+#define __u64 int
+
 #include <linux/loop.h>
 
 /* Avoid Debian warnings "implicit-function-declaration" */
@@ -39,3 +43,5 @@ int   execvp(const char *file, char *const argv[]);
 uid_t getuid(void);
 gid_t getgid(void);
 int   setenv(const char *, const char *, int);
+
+int find_unused_loop_device(char **ret);

--- a/hypervm/src/lxlogin.h
+++ b/hypervm/src/lxlogin.h
@@ -29,10 +29,14 @@
 
 #define OPENVZ_BINARY "vzctl"
 #define XEN_BINARY    "xm"
+#define SEARCH_PATHS  "PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin"
 
 /* Avoid Debian warnings "implicit-function-declaration" */
 int setegid(gid_t);
 int seteuid(uid_t);
-int putenv(char *);
+int putenv(const char *);
 
-char *get_vm_name();
+#ifndef _GET_VM_NAME_
+	#define _GET_VM_NAME_
+	char *get_vm_name();
+#endif

--- a/hypervm/src/lxopenvz.c
+++ b/hypervm/src/lxopenvz.c
@@ -24,7 +24,7 @@ int main()
 {
 	char *s;
 	s = get_vm_name();
-	putenv("PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin");
+	putenv(SEARCH_PATHS);
 	execlp(OPENVZ_BINARY, OPENVZ_BINARY, "enter", s, NULL);
 
 	return EXIT_SUCCESS;

--- a/hypervm/src/lxrestart.c
+++ b/hypervm/src/lxrestart.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv)
 		   for debugging purposes
 		 */
 		if (debug) {
-			printf("%s: Not allowed to execute\n", pwd->pw_name);
+			fprintf(stderr, "%s: Not allowed to execute\n", pwd->pw_name);
 		}
 		exit(0);
 	}
@@ -71,7 +71,5 @@ int main(int argc, char **argv)
 	seteuid(0);
 	
 	snprintf(buf, BUFSIZ - 1, "/etc/init.d/%s backendrestart", argv[1]);
-	system(buf);
-
-	return EXIT_SUCCESS;
+	return system(buf);
 }

--- a/hypervm/src/lxxen.c
+++ b/hypervm/src/lxxen.c
@@ -27,7 +27,7 @@ int main()
 	char *s;
 	s = get_vm_name(); /* This should return NULL if invalid */
 
-	putenv("PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin");
+	putenv(SEARCH_PATHS);
 	printf("Logging into Xen Virtual machine %s, Press Ctrl-] to Quit. Press a couple of Enters to start.\n", s);
 	execlp(XEN_BINARY, XEN_BINARY, "console", s, NULL);
 

--- a/hypervm/src/program-backend.h
+++ b/hypervm/src/program-backend.h
@@ -25,6 +25,7 @@
 #include <wait.h>
 #include <netdb.h>
 #include <unistd.h>
+#include <sys/select.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
@@ -55,10 +56,12 @@ char    * ssl_sock_read(int sock, SSL_CTX *ctx);
 int     tcp_sock_read(int sock);
 int     accept_and(int listen_sock);
 void    ssl_or_tcp_fork(int listen_socket, SSL_CTX *ctx);
-int     close_and_system(char *cmd);
+int     close_and_system(const char *cmd);
 int     process_timed(int counter);
 int     exec_scavenge();
 int     process_timed_in_child();
+
+#define SCAVENGE_TIME_FILE "../etc/conf/scavenge_time.conf"
 
 #define RSA_SERVER_CERT     "/usr/local/lxlabs/kloxo/file/backend.crt"
 #define RSA_SERVER_KEY          "/usr/local/lxlabs/kloxo/file/backend.key"


### PR DESCRIPTION
-I too fix the make all issue previously (I don't expect the Danny commit), so be cafeful if you have to make a git rebase for the conflict. Danny for avoid that, you should always make pull request and don't commit directly to master.
- Add more flags for pedantic warnings on makefile (solve more future problems for bad C programming).
- Put as constant the scanvenge file conf and patch search
- Other minor changes on declarations of code for avoid warnings
