### PR TITLE
Update more internal parameters for Fedora 16 and others

### DIFF
--- a/hypervm/bin/xen-dists/fedora-16.conf
+++ b/hypervm/bin/xen-dists/fedora-16.conf
@@ -1,0 +1,28 @@
+#  Copyright (C) 2000-2006 SWsoft. All rights reserved.
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# This configuration file is meant to be used with
+# the Fedora distribution kit.
+#
+
+ADD_IP=redhat-add_ip.sh
+DEL_IP=redhat-del_ip.sh
+SET_HOSTNAME=redhat-set_hostname.sh
+SET_DNS=set_dns.sh
+SET_USERPASS=set_userpass.sh
+SET_UGID_QUOTA=set_ugid_quota.sh
+POST_CREATE=postcreate.sh
+STARTUP_SCRIPT=systemd

--- a/hypervm/httpdocs/lib/vps/driver/vps__xenlib.php
+++ b/hypervm/httpdocs/lib/vps/driver/vps__xenlib.php
@@ -1652,53 +1652,88 @@ function setInternalParam($mountpoint)
 	$setuserpass = $result['SET_USERPASS'];
 	$ipdel = $result['DEL_IP'];
 
-	$name = createTempDir("$mountpoint/tmp", "xen-scripts");
-	lxfile_cp_rec("__path_program_root/bin/xen-dists/scripts/functions", $name);
-	lxfile_cp_rec("__path_program_root/bin/xen-dists/scripts/$ipadd", $name);
-	lxfile_cp_rec("__path_program_root/bin/xen-dists/scripts/$sethostname", $name);
-	lxfile_cp_rec("__path_program_root/bin/xen-dists/scripts/$setuserpass", $name);
-	lxfile_cp_rec("__path_program_root/bin/xen-dists/scripts/$ipdel", $name);
+        if ($this->main->networkgateway) {
+                $gw = $this->main->networkgateway;
+        } else {
+                $gw = os_get_network_gateway();
+        }
 
+        $gwn = strtil($gw, '.') . '.0';
 
-	$basepath = strfrom($name, $mountpoint);
-	lfile_put_contents("$name/tmpfile.sh", "source /$basepath/functions\nsource /$basepath/$ipdel\n");
-	$delipstring = "IPDELALL=yes chroot $mountpoint bash /$basepath/tmpfile.sh";
+        $hostname = $this->main->hostname;
+        if (!$hostname) { $hostname = os_get_hostname(); }
 
-	if ($this->main->networkgateway) {
-		$gw = $this->main->networkgateway;
-	} else {
-		$gw = os_get_network_gateway();
-	}
+	if ($result['STARTUP_SCRIPT'] != 'systemd'){
+            $name = createTempDir("$mountpoint/tmp", 'xen-scripts');
+	    lxfile_cp_rec("__path_program_root/bin/xen-dists/scripts/functions", $name);
+            lxfile_cp_rec("__path_program_root/bin/xen-dists/scripts/$ipadd", $name);
+	    lxfile_cp_rec("__path_program_root/bin/xen-dists/scripts/$sethostname", $name);
+            lxfile_cp_rec("__path_program_root/bin/xen-dists/scripts/$setuserpass", $name);
+            lxfile_cp_rec("__path_program_root/bin/xen-dists/scripts/$ipdel", $name);
 
-	log_shell($delipstring);
-	system($delipstring);
+	    $basepath = strfrom($name, $mountpoint);
+	    lfile_put_contents("$name/tmpfile.sh", "source /$basepath/functions\nsource /$basepath/$ipdel\n");
+	    $delipstring = "IPDELALL=yes chroot $mountpoint bash /$basepath/tmpfile.sh";
 
-	$gwn = strtil($gw, ".") . ".0";
-	putenv("VE_STATE=stopped");
-	lfile_put_contents("$name/tmpfile.sh", "source /$basepath/functions\n source /$basepath/$ipadd\n");
-	$string = "IPDELALL=yes MAIN_NETMASK=$main_netmask MAIN_IP_ADDRESS=$main_ip IP_ADDR=\"$iplist\" NETWORK_GATEWAY=$gw NETWORK_GATEWAY_NET=$gwn chroot $mountpoint bash /$basepath/tmpfile.sh";
+            log_shell($delipstring);
+            log_shell(system($delipstring,$ret1) . ":return $ret1");
 
-	log_shell($string);
-	system($string); 
+	    putenv("VE_STATE=stopped");
+	    lfile_put_contents("$name/tmpfile.sh", "source /$basepath/functions\n source /$basepath/$ipadd\n");
+	    $string = "IPDELALL=yes MAIN_NETMASK=$main_netmask MAIN_IP_ADDRESS=$main_ip IP_ADDR=\"$iplist\" NETWORK_GATEWAY=$gw NETWORK_GATEWAY_NET=$gwn chroot $mountpoint bash /$basepath/tmpfile.sh";
 
-	$hostname = $this->main->hostname;
-	if (!$hostname) { $hostname = os_get_hostname(); }
+	    log_shell($string);
+	    log_shell(system($string, $ret1) . ":return $ret1");
 
-	lfile_put_contents("$name/tmpfile.sh", "source /$basepath/functions\n source /$basepath/$sethostname\n");
-	$string = "HOSTNM=$hostname chroot $mountpoint bash /$basepath/tmpfile.sh";
-	log_shell($string);
-	system($string);
+	    lfile_put_contents("$name/tmpfile.sh", "source /$basepath/functions\n source /$basepath/$sethostname\n");
+	    $string = "HOSTNM=$hostname chroot $mountpoint bash /$basepath/tmpfile.sh";
+	    log_shell($string);
+	    log_shell(system($string,$ret1).":return $ret1");
 
-	if (($this->main->subaction === 'rebuild') || ($this->main->dbaction === 'add') || ($this->main->isOn('__var_rootpassword_changed') && $this->main->rootpassword)) {
+	    if (($this->main->subaction === 'rebuild') || ($this->main->dbaction === 'add') || ($this->main->isOn('__var_rootpassword_changed') && $this->main->rootpassword)) {
 		$rootpass = "root:{$this->main->rootpassword}";
 		lfile_put_contents("$name/tmpfile.sh", "source /$basepath/functions\n source /$basepath/$setuserpass\n");
 		$string = "USERPW=$rootpass chroot $mountpoint bash /$basepath/tmpfile.sh";
 		log_shell($string);
-		system($string);
+		log_shell(system($string));
+	    }
+		
+		lxfile_rm_rec($name);
 	}
+	else if ($result['STARTUP_SCRIPT'] == 'systemd'){
+		$script_dir = createTempDir("$mountpoint", "hypervm-runonce");
+		lxfile_cp_rec("__path_program_root/bin/xen-dists/scripts/functions", $script_dir);
+		lxfile_cp_rec("__path_program_root/bin/xen-dists/scripts/$ipadd", $script_dir);
+		lxfile_cp_rec("__path_program_root/bin/xen-dists/scripts/$sethostname", $script_dir);
+        lxfile_cp_rec("__path_program_root/bin/xen-dists/scripts/$setuserpass", $script_dir);
+		lxfile_cp_rec("__path_program_root/bin/xen-dists/scripts/$ipdel", $script_dir);
+		$basepath = strfrom($script_dir, $mountpoint);
+		$startupdir = 'lib/systemd/system';
+		$startupscript = 'fedora-startup.service';
 
+		$setrootpass = '';
+		if (($this->main->subaction === 'rebuild') || ($this->main->dbaction === 'add') || ($this->main->isOn('__var_rootpassword_changed') && $this->main->rootpassword)) {
+			$rootpass = "root:{$this->main->rootpassword}";
+			$setrootpass = " & USERPW=$rootpass source $basepath/$setuserpass";
+		}
 
-	lxfile_rm_rec($name);
+		$run_once_script = "#!/bin/bash\n" .
+			"source $basepath/functions\n" .
+			'(' .
+			"IPDELALL=yes source $basepath/$ipdel" .
+			" & IPDELALL=yes VE_STATE=stopped MAIN_NETMASK=$main_netmask MAIN_IP_ADDRESS=$main_ip IP_ADDR=\"$iplist\" NETWORK_GATEWAY=$gw NETWORK_GATEWAY_NET=$gwn source $basepath/$ipadd" .
+			" & HOSTNM=$hostname source $basepath/$sethostname" .
+			"$setrootpass)\n" .
+			"service fedora-startup disable\nrm -f /$startupdir/$startupscript\nrm -rf $basepath";
+		lfile_put_contents("$script_dir/hypervm-runonce.sh", $run_once_script);
+
+		lxfile_cp_rec("__path_program_root/bin/xen-dists/scripts/$startupscript", "$mountpoint/$startupdir");
+		lfile_put_contents("$mountpoint/$startupdir/$startupscript", 
+			lfile_get_contents("$mountpoint/$startupdir/$startupscript") .
+			"ExecStart=$basepath/hypervm-runonce.sh\n");
+		system("ln -s /lib/systemd/system/fedora-startup.service $mountpoint/etc/systemd/system/multi-user.target.wants/fedora-startup.service");
+		system("chmod 755 $script_dir/hypervm-runonce.sh");
+	}
 
 	if ($this->main->nameserver) {
 		$nlist = explode(" ", $this->main->nameserver);


### PR DESCRIPTION
Here is the original pull: https://github.com/lxcenter/hypervm/pull/7

Here is the issue: http://project.lxcenter.org/issues/764

HyperVM uses a chroot to set the internal parameters. The glibc in Fedora 16 is not compatible with the CentOS 5 kernel. So I set HyperVM to create startup scripts using Fedora's native systemd.  When Fedora 16 is rebooted from within HyperVM, the scripts are slipped in and are run by Fedora 16 on boot. This sets all the internal parameters like networking, hostname, etc.

Let me add that this isn't just for Fedora 16. I wrote it so that you can set a distro's file to systemd and it will work this way. I also think the same should be done for init.d distros in the future, but as Fedora 16 is the only one affected that I know of, I felt it was ok just to change what needed to be changed. There could be other distros that this will help as well.
