### PR TITLE
Core php53 bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .buildpath
 .project
 .settings/
+.externalToolBuilders/
 
 # Ignore binaries if already compiled
 hypervm/src/findfreeloop
@@ -14,4 +15,6 @@ hypervm/src/lxxen
 # Ignore .diff files on development
 *.diff
 
-
+# Ignore files from patches
+*.orig
+*.rej

--- a/hypervm/httpdocs/htmllib/coredisplaylib.php
+++ b/hypervm/httpdocs/htmllib/coredisplaylib.php
@@ -182,9 +182,9 @@ function __ac_desc_show($object)
 
 
 	$ghtml->print_message();
-	if ($ilist) {
+	//if ($ilist) {
 		//$ghtml->print_info_block($object, $ilist);
-	}
+	//}
 
 	$cname = $object->getClass();
 	$extra = $object->getExtraId();
@@ -1261,214 +1261,216 @@ function create_xml($object, $stuff, $ret)
 	$string = null;
 
 
-	foreach($vlist as $k => $v) {
-
-		if (csb($k, "__c_")) {
-			$cmd = substr($k, 4);
-			$cmd = substr($cmd, 0, strpos($cmd, '_'));
-			$string[] = $ghtml->object_variable_command($cmd, $v);
-			continue;
-		}
-
-		if (csb($k, "__v_") || csb($k, "__m_")) {
-			continue;
-		}
-
-
-		// Hack hack:: used_s is handled separately.. There is no other way, since without any other way to recognize it, quota variables  defaults to priv...
-		if (!csb($k, "used_s")) {
-			if ($v && $ghtml->is_special_variable($v[1])) {
-			} else {
-				$descr = $ghtml->get_classvar_description_after_overload($class, $k);
-				//dprintr($descr);
-				if (count($descr) < 3) {
-					dprint("Variable $k in $class Not Defined... <br> \n");
-					$descr = array($class, $k, "Not Defined");
-				}
-			}
-			lxclass::resolve_class_differences($class, $k, $dclass, $dk);
-		}
-
-
-		if ($k === "old_password_f") {
-			$string[] = $ghtml->object_variable_oldpassword($dclass, "old_password_f", $descr);
-			continue;
-		}
-
-		if ($k === "password" || $k === "dbpassword") {
-			$string[] = $ghtml->object_variable_password($class, $k);
-			continue;
-		}
-
-		if ($v) {
-			if (csa($v[0], 'I')) {
-				if ($v[1] && is_array($v[1])) {
-					$opt = $v[1];
-				} else {
-					$opt['value'] = $v[1];
-				}
-				$string[] = $ghtml->object_variable_image($stuff, $k, $opt);
-				$opt = null;
+	if(!empty($vlist)) {
+		foreach($vlist as $k => $v) {
+	
+			if (csb($k, "__c_")) {
+				$cmd = substr($k, 4);
+				$cmd = substr($cmd, 0, strpos($cmd, '_'));
+				$string[] = $ghtml->object_variable_command($cmd, $v);
 				continue;
 			}
-			if (csa($v[0], 'L')) {
-				if ($v[1] && is_array($v[1])) {
-					$opt = $v[1];
-				} else {
-					$opt['fvalue'] = $v[1];
-				}
-				$string[] = $ghtml->object_variable_fileselect($stuff, $k, $opt);
-				$opt = null;
+	
+			if (csb($k, "__v_") || csb($k, "__m_")) {
 				continue;
 			}
-			if (csa($v[0], 'm')) {
-				if ($v[1] && is_array($v[1])) {
-					$opt = $v[1];
+	
+	
+			// Hack hack:: used_s is handled separately.. There is no other way, since without any other way to recognize it, quota variables  defaults to priv...
+			if (!csb($k, "used_s")) {
+				if ($v && $ghtml->is_special_variable($v[1])) {
 				} else {
-					$opt['value'] = $v[1];
+					$descr = $ghtml->get_classvar_description_after_overload($class, $k);
+					//dprintr($descr);
+					if (count($descr) < 3) {
+						dprint("Variable $k in $class Not Defined... <br> \n");
+						$descr = array($class, $k, "Not Defined");
+					}
 				}
-				$string[] = $ghtml->object_variable_modify($stuff, $k, $opt);
-				$opt = null;
+				lxclass::resolve_class_differences($class, $k, $dclass, $dk);
+			}
+	
+	
+			if ($k === "old_password_f") {
+				$string[] = $ghtml->object_variable_oldpassword($dclass, "old_password_f", $descr);
 				continue;
 			}
-			if (csa($v[0], 'E')) {
-				if (!$v[1]) {
-					$list = exec_class_method($dclass, "getSelectList", $object, $dk);
-				} else {
-					$list = $v[1];
-				}
-				$string[] = $ghtml->object_variable_selectradio($class, $k, $list);
-				$list = null;
+	
+			if ($k === "password" || $k === "dbpassword") {
+				$string[] = $ghtml->object_variable_password($class, $k);
 				continue;
 			}
-
-			if (csa($v[0], 's')) {
-				if (!$v[1]) {
-					$list = exec_class_method($dclass, "getSelectList", $object, $dk);
-				} else {
-					$list = $v[1];
+	
+			if ($v) {
+				if (csa($v[0], 'I')) {
+					if ($v[1] && is_array($v[1])) {
+						$opt = $v[1];
+					} else {
+						$opt['value'] = $v[1];
+					}
+					$string[] = $ghtml->object_variable_image($stuff, $k, $opt);
+					$opt = null;
+					continue;
 				}
-				$string[] = $ghtml->object_variable_select($stuff, $k, $list);
-				$list = null;
+				if (csa($v[0], 'L')) {
+					if ($v[1] && is_array($v[1])) {
+						$opt = $v[1];
+					} else {
+						$opt['fvalue'] = $v[1];
+					}
+					$string[] = $ghtml->object_variable_fileselect($stuff, $k, $opt);
+					$opt = null;
+					continue;
+				}
+				if (csa($v[0], 'm')) {
+					if ($v[1] && is_array($v[1])) {
+						$opt = $v[1];
+					} else {
+						$opt['value'] = $v[1];
+					}
+					$string[] = $ghtml->object_variable_modify($stuff, $k, $opt);
+					$opt = null;
+					continue;
+				}
+				if (csa($v[0], 'E')) {
+					if (!$v[1]) {
+						$list = exec_class_method($dclass, "getSelectList", $object, $dk);
+					} else {
+						$list = $v[1];
+					}
+					$string[] = $ghtml->object_variable_selectradio($class, $k, $list);
+					$list = null;
+					continue;
+				}
+	
+				if (csa($v[0], 's')) {
+					if (!$v[1]) {
+						$list = exec_class_method($dclass, "getSelectList", $object, $dk);
+					} else {
+						$list = $v[1];
+					}
+					$string[] = $ghtml->object_variable_select($stuff, $k, $list);
+					$list = null;
+					continue;
+				}
+	
+				if (csa($v[0], 'A')) {
+					if (!$v[1]) {
+						$list = exec_class_method($dclass, "getSelectList", $object, $dk);
+					} else {
+						$list = $v[1];
+					}
+					$string[] = $ghtml->object_variable_select($stuff, $k, $list, true);
+					$list = null;
+					continue;
+				}
+	
+				if (csa($v[0], 'Q')) {
+					$string[] = $ghtml->object_variable_listquota($object, $stuff, $k, $v[1]);
+					continue;
+				}
+	
+	
+				if (csa($v[0], 'U')) {
+					if (!$v[1]) {
+						$list = exec_class_method($dclass, "getSelectList", $object, $dk);
+					} else {
+						$list = $v[1];
+					}
+					$string[] = $ghtml->object_variable_multiselect($stuff, $k, $list);
+					$list = null;
+					continue;
+				}
+	
+	
+				if (csa($v[0], 'V')) {
+					$string[] = $ghtml->object_variable_htmltextarea($stuff, $k, $v[1]);
+					continue;
+				}
+				if (csa($v[0], 't')) {
+					$string[] = $ghtml->object_variable_textarea($stuff, $k, $v[1]);
+					continue;
+				}
+				if (csa($v[0], 'T')) {
+					$string[] = $ghtml->object_variable_textarea($stuff, $k, $v[1], true);
+					continue;
+				}
+	
+				if (csa($v[0], 'h')) {
+					$string[] = $ghtml->object_variable_hidden("frm_" . $class . "_c_" . $k, $v[1]);
+					continue;
+				}
+	
+				if (csa($v[0], 'f')) {
+					$string[] = $ghtml->object_variable_check($stuff, $k, $v[1]);
+					continue;
+				}
+	
+				if (csa($v[0], 'M')) {
+					$string[] = $ghtml->object_variable_nomodify($stuff, $k, $v[1]);
+					continue;
+				}
+			}
+	
+			if (csa($descr[0], 'F')) {
+				$string[] = $ghtml->object_variable_file($stuff, $k);
 				continue;
 			}
-
-			if (csa($v[0], 'A')) {
-				if (!$v[1]) {
-					$list = exec_class_method($dclass, "getSelectList", $object, $dk);
-				} else {
-					$list = $v[1];
-				}
-				$string[] = $ghtml->object_variable_select($stuff, $k, $list, true);
-				$list = null;
+	
+			if (csa($descr[0], 'E')) {
+				$list = exec_class_method($dclass, "getSelectList", $object, $dk);
+				$string[] = $ghtml->object_variable_selectradio($stuff, $k, $list);
 				continue;
 			}
-
-			if (csa($v[0], 'Q')) {
-				$string[] = $ghtml->object_variable_listquota($object, $stuff, $k, $v[1]);
-				continue;
-			}
-
-
-			if (csa($v[0], 'U')) {
-				if (!$v[1]) {
-					$list = exec_class_method($dclass, "getSelectList", $object, $dk);
-				} else {
-					$list = $v[1];
-				}
+			if (csa($descr[0], 'U')) {
+				$list = exec_class_method($dclass, "getSelectList", $object, $dk);
 				$string[] = $ghtml->object_variable_multiselect($stuff, $k, $list);
-				$list = null;
 				continue;
 			}
-
-
-			if (csa($v[0], 'V')) {
-				$string[] = $ghtml->object_variable_htmltextarea($stuff, $k, $v[1]);
+	
+			if (csa($descr[0], 'f')) {
+				$string[] = $ghtml->object_variable_check($stuff, $k);
 				continue;
 			}
-			if (csa($v[0], 't')) {
-				$string[] = $ghtml->object_variable_textarea($stuff, $k, $v[1]);
+	
+			if (csa($descr[0], 'e') || csa($descr[0], 's')) {
+				$list = exec_class_method($dclass, "getSelectList", $object, $dk);
+				$string[] = $ghtml->object_variable_select($stuff, $k, $list, false);
 				continue;
 			}
-			if (csa($v[0], 'T')) {
-				$string[] = $ghtml->object_variable_textarea($stuff, $k, $v[1], true);
+	
+			if (csa($descr[0], 'A')) {
+				$list = exec_class_method($dclass, "getSelectList", $object, $dk);
+				$string[] = $ghtml->object_variable_select($stuff, $k, $list, true);
 				continue;
 			}
-
-			if (csa($v[0], 'h')) {
-				$string[] = $ghtml->object_variable_hidden("frm_" . $class . "_c_" . $k, $v[1]);
+	
+	
+			if (csa($descr[0], 't')) {
+				$string[] = $ghtml->object_variable_textarea($stuff, $k);
 				continue;
 			}
-
-			if (csa($v[0], 'f')) {
-				$string[] = $ghtml->object_variable_check($stuff, $k, $v[1]);
+			if (csa($descr[0], 'T')) {
+				$string[] = $ghtml->object_variable_textarea($stuff, $k, null, true);
 				continue;
 			}
-
-			if (csa($v[0], 'M')) {
-				$string[] = $ghtml->object_variable_nomodify($stuff, $k, $v[1]);
+	
+			if (csa($descr[0], 'q')) {
+				$string[] = $ghtml->object_variable_quota($object, $stuff, $k);
 				continue;
 			}
+			if (csa($descr[0], 'Q')) {
+				$string[] = $ghtml->object_variable_listquota($object, $stuff, $k);
+				continue;
+			}
+	
+	
+	
+			$string[] = $ghtml->object_variable_modify($stuff, $k);
+	
 		}
-
-		if (csa($descr[0], 'F')) {
-			$string[] = $ghtml->object_variable_file($stuff, $k);
-			continue;
-		}
-
-		if (csa($descr[0], 'E')) {
-			$list = exec_class_method($dclass, "getSelectList", $object, $dk);
-			$string[] = $ghtml->object_variable_selectradio($stuff, $k, $list);
-			continue;
-		}
-		if (csa($descr[0], 'U')) {
-			$list = exec_class_method($dclass, "getSelectList", $object, $dk);
-			$string[] = $ghtml->object_variable_multiselect($stuff, $k, $list);
-			continue;
-		}
-
-		if (csa($descr[0], 'f')) {
-			$string[] = $ghtml->object_variable_check($stuff, $k);
-			continue;
-		}
-
-		if (csa($descr[0], 'e') || csa($descr[0], 's')) {
-			$list = exec_class_method($dclass, "getSelectList", $object, $dk);
-			$string[] = $ghtml->object_variable_select($stuff, $k, $list, false);
-			continue;
-		}
-
-		if (csa($descr[0], 'A')) {
-			$list = exec_class_method($dclass, "getSelectList", $object, $dk);
-			$string[] = $ghtml->object_variable_select($stuff, $k, $list, true);
-			continue;
-		}
-
-
-		if (csa($descr[0], 't')) {
-			$string[] = $ghtml->object_variable_textarea($stuff, $k);
-			continue;
-		}
-		if (csa($descr[0], 'T')) {
-			$string[] = $ghtml->object_variable_textarea($stuff, $k, null, true);
-			continue;
-		}
-
-		if (csa($descr[0], 'q')) {
-			$string[] = $ghtml->object_variable_quota($object, $stuff, $k);
-			continue;
-		}
-		if (csa($descr[0], 'Q')) {
-			$string[] = $ghtml->object_variable_listquota($object, $stuff, $k);
-			continue;
-		}
-
-
-
-		$string[] = $ghtml->object_variable_modify($stuff, $k);
-
 	}
-
+	
 	$string[] = $ghtml->object_variable_hidden("frm_action", $action);
 
 	if (isset($ret['subaction'])) {

--- a/hypervm/httpdocs/htmllib/lib/client/clientbaselib.php
+++ b/hypervm/httpdocs/htmllib/lib/client/clientbaselib.php
@@ -345,7 +345,7 @@ function createShowAlist(&$alist, $subaction = null)
 
 
 
-function createShowAlistConfig(&$alist)
+function createShowAlistConfig(&$alist, $subaction = null)
 {
 	global $gbl, $sgbl, $login, $ghtml; 
 

--- a/hypervm/httpdocs/htmllib/lib/commonfslib.php
+++ b/hypervm/httpdocs/htmllib/lib/commonfslib.php
@@ -57,7 +57,12 @@ function lxshell_redirect($file, $cmd)
 {
 	global $gbl, $sgbl, $login, $ghtml; 
 	$start = 2;
-	eval($sgbl->arg_getting_string);
+	$arglist = array();
+	$nargs = @func_num_args();
+	if($nargs > 0)
+		for ($i = $start; $i < $nargs; $i++)
+			$arglist[] = (isset($transforming_func)) ? $transforming_func(func_get_arg($i)) : func_get_arg($i);
+	
 	$cmd = getShellCommand($cmd, $arglist);
 	$return = null;
 	system("$cmd > $file 3</dev/null 4</dev/null 5</dev/null 6</dev/null", $return);
@@ -72,7 +77,12 @@ function lxshell_directory($dir, $cmd)
 	$username = '__system__';
 
 	$start = 2;
-	eval($sgbl->arg_getting_string);
+	$arglist = array();
+	$nargs = @func_num_args();
+	if($nargs > 0)
+		for ($i = $start; $i < $nargs; $i++)
+			$arglist[] = (isset($transforming_func)) ? $transforming_func(func_get_arg($i)) : func_get_arg($i);
+	
 	$cmd = getShellCommand($cmd, $arglist);
 	do_exec_system($username, $dir, $cmd, $out, $err, $ret, null);
 	return $out;
@@ -85,7 +95,13 @@ function lxshell_output($cmd)
 	$username = '__system__';
 
 	$start = 1;
-	eval($sgbl->arg_getting_string);
+	
+	$arglist = array();
+	$nargs = @func_num_args();
+	if($nargs > 0)
+		for ($i = $start; $i < $nargs; $i++)
+			$arglist[] = (isset($transforming_func)) ? $transforming_func(func_get_arg($i)) : func_get_arg($i);
+	
 	$cmd = getShellCommand($cmd, $arglist);
 	do_exec_system($username, null, $cmd, $out, $err, $ret, null);
 	return $out;
@@ -96,7 +112,12 @@ function lxshell_user_return($username, $cmd)
 {
 	global $sgbl;
 	$start = 2;
-	eval($sgbl->arg_getting_string);
+	$arglist = array();
+	$nargs = @func_num_args();
+	if($nargs > 0)
+		for ($i = $start; $i < $nargs; $i++)
+			$arglist[] = (isset($transforming_func)) ? $transforming_func(func_get_arg($i)) : func_get_arg($i);
+	
 	$cmd = getShellCommand($cmd, $arglist);
 	$ret = new_process_cmd($username, null, $cmd);
 	return $ret;
@@ -108,10 +129,16 @@ function lxshell_return($cmd)
 	$username = '__system__';
 
 	$start = 1;
-	eval($sgbl->arg_getting_string);
+	$arglist = array();
+	$nargs = @func_num_args();
+	if($nargs > 0)
+		for ($i = $start; $i < $nargs; $i++)
+			$arglist[] = (isset($transforming_func)) ? $transforming_func(func_get_arg($i)) : func_get_arg($i);
+	
 
 	$cmd = getShellCommand($cmd, $arglist);
 	do_exec_system($username, null, $cmd, $out, $err, $ret, null);
+
 	return $ret;
 }
 
@@ -126,7 +153,12 @@ function lxshell_input($input, $cmd)
 	$username = '__system__';
 
 	$start = 2;
-	eval($sgbl->arg_getting_string);
+	$arglist = array();
+	$nargs = @func_num_args();
+	if($nargs > 0)
+		for ($i = $start; $i < $nargs; $i++)
+			$arglist[] = (isset($transforming_func)) ? $transforming_func(func_get_arg($i)) : func_get_arg($i);
+	
 	$cmd = getShellCommand($cmd, $arglist);
 	do_exec_system($username, null, $cmd, $out, $err, $ret, $input);
 	return $ret;

--- a/hypervm/httpdocs/htmllib/lib/dns/dnsbaselib.php
+++ b/hypervm/httpdocs/htmllib/lib/dns/dnsbaselib.php
@@ -36,7 +36,7 @@ function updateform($subaction, $param)
 	return $vlist;
 }
 
-function isAction()
+function isAction($var)
 {
 	if ($this->ttype === 'ns') {
 		return false;
@@ -44,7 +44,7 @@ function isAction()
 	return true;
 }
 
-static function createListNlist($parent, $view)
+static function createListNlist($parent, $view = NULL)
 {
 
 	//$nlist['nname'] = '10%';

--- a/hypervm/httpdocs/htmllib/lib/ippoollib.php
+++ b/hypervm/httpdocs/htmllib/lib/ippoollib.php
@@ -7,7 +7,7 @@ class ippoolextraip_a extends Lxaclass {
 static $__desc = array("", "", "extra_ip");
 static $__desc_nname = array("n", "", "ipaddress");
 
-static function createListAlist($parent, $class)
+static function createListAlist($parent, $class = NULL)
 {
 	$alist[] = 'a=show';
 	$alist[] = 'a=list&c=ippoolip';
@@ -24,7 +24,7 @@ class ippoolexceptionip_a extends Lxaclass {
 static $__desc = array("", "", "exception_ip");
 static $__desc_nname = array("n", "", "ipaddress");
 
-static function createListAlist($parent, $class)
+static function createListAlist($parent, $class = NULL)
 {
 	return ippoolextraip_a::createListAlist($parent, $class);
 	return $alist;
@@ -39,7 +39,7 @@ static $__desc_nname = array("n", "", "ipaddress");
 
 
 
-static function createListAlist($parent, $class)
+static function createListAlist($parent, $class = NULL)
 {
 	return ippoolextraip_a::createListAlist($parent, $class);
 	return $alist;
@@ -65,13 +65,13 @@ static function initThisList($parent, $class)
 }
 
 function isSelect() { return false ; }
-static function createListNlist($parent, $view)
+static function createListNlist($parent, $view = NULL)
 {
 	$nlist['nname'] = '100%';
 	$nlist['assigned'] = '40%';
 	return $nlist;
 }
-static function createListAlist($parent, $class)
+static function createListAlist($parent, $class = NULL)
 {
 	return ippoolextraip_a::createListAlist($parent, $class);
 }
@@ -113,7 +113,7 @@ static function add($parent, $class, $param)
 	validate_ipaddress_and_throw($param['lastip'], 'lastip');
 
 	if (!$param['pserver_list']) {
-		throw new lxException ("need_to_select_pserver", 'pserver_list');
+		throw new lxException ('It is needed select a production server from the list', 'pserver_list');
 	}
 
 	$param['pserver_list'] = explode(',', $param['pserver_list']);

--- a/hypervm/httpdocs/htmllib/lib/lib.php
+++ b/hypervm/httpdocs/htmllib/lib/lib.php
@@ -13,7 +13,7 @@ function getNumForString($name)
 
 function is_openvz()
 {
-	return lxfile_exists("/proc/user_beancounters");
+	return lxfile_exists("/proc/user_beancounters");  
 }
 
 
@@ -1158,6 +1158,7 @@ function mycount($olist)
 
 function full_validate_ipaddress($ip, $variable = 'ipaddress')
 {
+	// variable is nname or ipaddress
 	global $gbl, $sgbl, $login, $ghtml; 
 	global $global_dontlogshell;
 	$global_dontlogshell = true;
@@ -1166,13 +1167,14 @@ function full_validate_ipaddress($ip, $variable = 'ipaddress')
 
 
 	if (!validate_ipaddress($ip)) {
-		throw new lxException("invalid_ipaddress", $variable);
+		throw new lxException('Invalid IP address: ' . $ip, $variable);
 	}
 
 	$ret = lxshell_return("ping", "-n", "-c", "1", "-w", "5", $ip);
-
-	if (!$ret) {
-		throw new lxexception("some_other_host_uses_this_ip", $variable);
+	
+	// If the return status is 1, the ping fail and nobody uses. But if return is 0, somebody is using the IP
+	if(intval($ret) !== 1) { 
+		throw new lxexception('Another host is using the IP ' . $ip . ' and it is responding to the IP ping. Please you will ensure to use an available IP to add.', $variable);
 	}
 
 	$global_dontlogshell = false;
@@ -1213,7 +1215,7 @@ function do_actionlog($login, $object, $action, $subaction)
 
 function validate_email($email)
 {
-	if(!eregi("^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,5})$", $email)){
+	if(!preg_match("#^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,5})$#", $email)){
 		return false;
 	}
 	return true;
@@ -1223,7 +1225,7 @@ function validate_email($email)
 function validate_ipaddress_and_throw($ip, $variable)
 {
 	if (!validate_ipaddress($ip)) {
-		throw new lxException("invalid_ipaddress", $variable);
+		throw new lxException('Invalid IP address: ' . $ip, $variable);
 	}
 }
 

--- a/hypervm/httpdocs/htmllib/lib/pserver/cronlib.php
+++ b/hypervm/httpdocs/htmllib/lib/pserver/cronlib.php
@@ -107,7 +107,7 @@ function createExtraVariables()
 }
 
 
-static function  createListNlist($parent)
+static function  createListNlist($parent, $class = NULL)
 {
 	//$nlist["nname"] = "5%";
 	//$nlist["minute"] = "5%";

--- a/hypervm/httpdocs/htmllib/lib/pserver/datacenterlib.php
+++ b/hypervm/httpdocs/htmllib/lib/pserver/datacenterlib.php
@@ -42,7 +42,7 @@ static function addform($parent, $class, $typetd = null)
 	return $ret;
 }
 
-function updateForm()
+function updateForm($subaction, $param)
 {
 	$vlist['nname'] = array('M', null);
 	$vlist['description'] = null;

--- a/hypervm/httpdocs/htmllib/lib/pserver/dirlocationlib.php
+++ b/hypervm/httpdocs/htmllib/lib/pserver/dirlocationlib.php
@@ -13,13 +13,13 @@ static function getExtraParameters($parent, $list)
 	return $parent->getExtraP('xen_location_a', $list);
 }
 
-static function createListNlist($parent, $view)
+static function createListNlist($parent, $view = NULL)
 {
 	$nlist['nname'] = '100%';
 	$nlist['diskfree'] = '50%';
 	return $nlist;
 }
-static function createListAlist($parent, $class)
+static function createListAlist($parent, $class = NULL)
 {
 
 	global $gbl, $sgbl, $login, $ghtml; 

--- a/hypervm/httpdocs/htmllib/lib/pserver/diskusagelib.php
+++ b/hypervm/httpdocs/htmllib/lib/pserver/diskusagelib.php
@@ -37,7 +37,7 @@ Function display($var)
 
 
 
-static  function createListNlist($parent)
+static  function createListNlist($parent, $class = NULL)
 {
 	$nlist["nname"] = "100%";
 	$nlist["used"] = "15%";

--- a/hypervm/httpdocs/htmllib/lib/pserver/pservercorelib.php
+++ b/hypervm/httpdocs/htmllib/lib/pserver/pservercorelib.php
@@ -21,7 +21,7 @@ static $__desc_nname	 = array("n", "",  "server_role");
 
 static function createListAddForm($parent, $class) { return true;}
 
-static function createListAlist($parent, $class)
+static function createListAlist($parent, $class = NULL)
 {
 	global $gbl, $sgbl, $login, $ghtml; 
 
@@ -235,7 +235,7 @@ function getIpPool($totalneeded)
 	}
 	$list = $this->getList('ippool');
 	if (!$list) {
-		throw new lxException("no_ippool_configured_for_this_slave", null, $this->nname);
+		throw new lxException('This slave has not a IP pool configured.', null, $this->nname);
 	}
 	$totallist = null;
 	$newnum = $totalneeded;
@@ -315,7 +315,7 @@ static function createServerInfo($list, $class = null)
 	return $ret;
 }
 
-static function  createListNlist($parent)
+static function  createListNlist($parent, $class = NULL)
 {
 
 	//$nlist['cpstatus'] = '3%';
@@ -420,12 +420,14 @@ function createShowRlist($subaction)
 		$rlist[] = array('lvm', "{$c['nname']}", $c['used'], $c['total']);
 	}
 	$disk = $l['disk'];
-	foreach($disk as $k => $c) {
-		$c['nname'] = str_replace(":", "_", $c['nname']);
-		if (csa($c['nname'], "mapper")) {
-			$c['nname'] = strfrom($c['nname'], "/dev/mapper/");
+	if(!empty($disk)) {
+		foreach($disk as $k => $c) {
+			$c['nname'] = str_replace(":", "_", $c['nname']);
+			if (csa($c['nname'], "mapper")) {
+				$c['nname'] = strfrom($c['nname'], "/dev/mapper/");
+			}
+			$rlist[] = array('disk', "{$c['mountedon']} ({$c['nname']})", $c['used'], $c['kblock']);
 		}
-		$rlist[] = array('disk', "{$c['mountedon']} ({$c['nname']})", $c['used'], $c['kblock']);
 	}
 	/// Rlist takes an array... 
 	$rlist[] = array('memory_usage', "Memory:Memory Usage (MB)",  $l['used_s_memory'], $l['priv_s_memory']);
@@ -442,9 +444,11 @@ function createShowRlist($subaction)
 	$rlist[] = array('Server Traffic', "Traffic:Server Traffic For Last Month", $this->used->server_traffic_last_usage, '-');
 
 	$cpu = $l['cpu'];
-	foreach($cpu as $k => $c) {
-		//$rlist[] = array('cpu', "CPU$k Model (speed)",  "{$c['used_s_cpumodel']} ({$c['used_s_cpuspeed']})", '-');
-		$rlist[] = array('cpu', "CPU$k speed",  "{$c['used_s_cpuspeed']}", '-');
+	if(!empty($cpu)) {
+		foreach($cpu as $k => $c) {
+			//$rlist[] = array('cpu', "CPU$k Model (speed)",  "{$c['used_s_cpumodel']} ({$c['used_s_cpuspeed']})", '-');
+			$rlist[] = array('cpu', "CPU$k speed",  "{$c['used_s_cpuspeed']}", '-');
+		}
 	}
 
 

--- a/hypervm/httpdocs/htmllib/phplib/common.inc
+++ b/hypervm/httpdocs/htmllib/phplib/common.inc
@@ -33,10 +33,16 @@ function __autoload($class)
 */
 
 	if (csb($class, "all_")) { $class = strfrom($class, "all_"); }
-	if (file_exists(getreal($gl_class_array[$class]))) {
-		include_once $gl_class_array[$class];
-		return;
+	
+	if(isset($gl_class_array[$class])) {
+		$class_name = $gl_class_array[$class];
+		
+		if (file_exists(getreal($class_name))) {
+			include_once $class_name;
+			return;
+		}
 	}
+	
 	dprint("Class Not found $class <br> \n");
 }
 

--- a/hypervm/httpdocs/htmllib/phplib/lib/generallib.php
+++ b/hypervm/httpdocs/htmllib/phplib/lib/generallib.php
@@ -8,7 +8,7 @@ class helpdeskcategory_a extends Lxaclass {
 	static $__desc_nname =  array("", "",  "category");
 
 
-static function createListAlist($parent)
+static function createListAlist($parent, $class = NULL)
 {
 	$nalist = ticket::createListAlist($parent, 'ticket');
 	foreach($nalist as $a) {

--- a/hypervm/httpdocs/htmllib/phplib/lib/lxclass.php
+++ b/hypervm/httpdocs/htmllib/phplib/lib/lxclass.php
@@ -3003,7 +3003,12 @@ function defaultValue($var)
 
 function getVariable($var)
 {
-	return $this->$var;
+	if(isset($this->$var)) {
+		return $this->$var;
+	}
+	else {
+		return NULL;
+	}
 }
 
 static function exec_collectQuota()
@@ -3079,8 +3084,12 @@ function display($var)
 		return null;
 	}
 
-	return $this->$var;
-
+	if(isset($this->$var)) {
+		return $this->$var;
+	}
+	else {
+		return NULL;
+	}
 }
 
 
@@ -3388,7 +3397,6 @@ final function setFromObject($obj)
 
 final function setFromArray($array)
 {
-
 	foreach($array as $key => $value) {
 		if (is_numeric($key)) {
 			//dprint("The Key is {$key} integer in .  {$this->get__table()}:{$this->nname} <br> ");
@@ -3430,32 +3438,36 @@ final function setFromArray($array)
 
 		if (csb($key, "ser_")) {
 			$key = strfrom($key, "ser_");
-			$value = unserialize(base64_decode($value));
-			if ($value === false) {
-				dprint("Unserialize failed: {$this->get__table()}: {$key}<br>\n", 3);
-				if (cse($key, "_b") && !is_object($value)) {
-					$value = new $key(null, null, $this->nname);
-					$this->$key = $value;
-					continue;
-				}
-			} else {
-
-				if (cse($key, "_b") && !is_object($value)) {
+			
+			if(!empty($value))
+			{
+				$value = unserialize(base64_decode($value));
+				if ($value === false) {
 					dprint("Unserialize failed: {$this->get__table()}: {$key}<br>\n", 3);
-					$value = new $key(null, null, $this->nname);
-					$this->$key = $value;
-					continue;
+					if (cse($key, "_b") && !is_object($value)) {
+						$value = new $key(null, null, $this->nname);
+						$this->$key = $value;
+						continue;
+					}
+				} else {
+	
+					if (cse($key, "_b") && !is_object($value)) {
+						//dprint("Unserialize failed for table {$this->get__table()} with key {$key}<br>\n", 3);
+						$value = new $key(null, null, $this->nname);
+						$this->$key = $value;
+						continue;
+					}
 				}
-			}
-
-			if (cse($key, "_a")) {
-				if ($value) foreach($value as $k => $v) {
-					$value[$k]->__parent_o = $this;
+	
+				if (cse($key, "_a")) {
+					if ($value) foreach($value as $k => $v) {
+						$value[$k]->__parent_o = $this;
+					}
 				}
+	
+				$this->$key = $value;
+				continue;
 			}
-
-			$this->$key = $value;
-			continue;
 		}
 
 
@@ -5833,7 +5845,7 @@ function showPrivInResource()
 class LxaClass extends Lxclass {
 function get() {}
 function write() {}
-static function createListAlist($parent, $class)
+static function createListAlist($parent, $class = NULL)
 {
 	return null;
 }

--- a/hypervm/httpdocs/htmllib/phplib/lib/lxdb.php
+++ b/hypervm/httpdocs/htmllib/phplib/lib/lxdb.php
@@ -86,10 +86,18 @@ static function initThisListRule($parent, $class)
 
 	$listvar = "{$class}_l";
 
-	$parent->checkChildExists($class);
+	$ret = array();
+	if(!empty($parent))	{
+		$parent->checkChildExists($class);
 
-
-	$ret[] = array('parent_clname', '=', "'{$parent->getClName()}'");
+		$ret[] = array('parent_clname', '=', "'{$parent->getClName()}'");
+	}
+	else
+	{
+		dprint('Warning ' . $class . ' have a missing parent<br />');
+		debug_for_backend();
+	} 
+	
 	return $ret;
 
 

--- a/hypervm/httpdocs/htmllib/phplib/lib/resourcelib.php
+++ b/hypervm/httpdocs/htmllib/phplib/lib/resourcelib.php
@@ -258,7 +258,7 @@ static function initThisList($parent, $class)
 	return $res;
 }
 
-static function createListAlist($parent, $class)
+static function createListAlist($parent, $class = NULL)
 {
 	$v = $parent->createShowAlist($alist);
 	return $v['property'];

--- a/hypervm/httpdocs/htmllib/phplib/lib/ssession.php
+++ b/hypervm/httpdocs/htmllib/phplib/lib/ssession.php
@@ -190,10 +190,12 @@ static function initThisList($parent, $class)
 	foreach($list as $l) {
 		$pp = lfile_get_json_unserialize("__path_program_root/session/$l");
 		if (!$pp) { lunlink("__path_program_root/session/$l"); continue; }
-		if (!$parent->isAdmin()) {
-			//$result = $db->getRowsWhere("parent_clname = '" . $parent->getClName() . "'");
-			if ($pp['parent_clname'] !== $parent->getClName()) {
-				continue;
+		if(!empty($parent)) {
+			if (!$parent->isAdmin()) {
+				//$result = $db->getRowsWhere("parent_clname = '" . $parent->getClName() . "'");
+				if ($pp['parent_clname'] !== $parent->getClName()) {
+					continue;
+				}
 			}
 		}
 		$result[] = $pp;
@@ -202,7 +204,9 @@ static function initThisList($parent, $class)
 
 
 	if ($result) {
-		$parent->setListFromArray($parent->__masterserver, $parent->__readserver, 'ssessionlist', $result, true);
+		if(!empty($parent)) {
+			$parent->setListFromArray($parent->__masterserver, $parent->__readserver, 'ssessionlist', $result, true);
+		}
 	}
 	return null;
 }

--- a/hypervm/httpdocs/htmllib/phplib/lxlib.php
+++ b/hypervm/httpdocs/htmllib/phplib/lxlib.php
@@ -82,6 +82,7 @@ function check_for_debug($file)
 	} else {
 		$sgbl->dbg = -1;
 	}
+
 	if ($sgbl->dbg > 0) {
 		ini_set("error_reporting", E_ALL & ~E_STRICT);
 		ini_set("display_errors", "On");
@@ -201,7 +202,7 @@ function find_os_pointversion()
 }
 
 function lscandir_without_dot($arg, $dotflag = false)
-{
+{  
 	$list = lscandir($arg);
 
 	if (!$list) {
@@ -464,42 +465,59 @@ function new_process_cmd($user, $dir, $cmd)
 function lfile_put_contents($file, $data, $flag = null)
 {
 	$file = expand_real_root($file);
-
+	
 	if (is_soft_or_hardlink($file)) {
 		log_log("link_error", "$file is hard or symlink. Not writing\n");
 		return;
 	}
-
+	
 	if (char_search_a($data, "__path_")) {
 		dprint("<font color=red>Warning : Trying to write __path into a file $file: </font> $data <br> \n", 3);
 	}
 
+
 	lxfile_mkdir(dirname($file));
 
-	if (file_exists($file)){
-		if (is_readable($file)){
-			if (is_writable($file)){
-				return file_put_contents($file, $data, $flag);
+	if(file_exists($file))
+	{
+		if(is_readable($file))
+		{
+			if(is_writable($file)){
+				$result = file_put_contents($file, $data, $flag);
+				chown($file, 'lxlabs');
+				return $result;
 			}
 			else{
-				$error_msg = 'Could not write the file \''.$file.'\' with permissions: '.substr(sprintf('%o', fileperms($file)), -4);
+				$posix_data = posix_getpwuid(fileowner($file));
+				$error_msg = 'Could not write the file \'' . $file . '\' with permissions: ' .
+				substr(sprintf('%o', fileperms($file)), -4) .
+                ' UID: ' . $posix_data['name'] .  ':' . $posix_data['uid'] .
+                ' GID: ' . $posix_data['gecos'] .  ':' . $posix_data['gid'] .
+				( PHP_SAPI !== 'cgi-fcgi' ? PHP_EOL : '<br />');
+
 				dprint($error_msg);
-				log_log('filesys', $error_msg);
+				//log_log('filesys', $error_msg);
 				return false;
 			}
 		}
-		else{
-			$error_msg = 'Could not read the file \''.$file.'\' with permissions: '.substr(sprintf('%o', fileperms($file)), -4);
+		else
+		{
+			$error_msg = 'Could not read the file \''.$file.'\' with permissions: '.substr(sprintf('%o', fileperms($file)), -4) . ( PHP_SAPI !== 'cgi-fcgi' ? PHP_EOL : '<br />');
 			dprint($error_msg);
-			log_log('filesys', $error_msg);
+			//log_log('filesys', $error_msg);
 			return false;
 		}
 	}
-	else{
-		if (file_put_contents($file, $data, $flag) === false){
+	else
+	{
+		$result = file_put_contents($file, $data, $flag);
+		chown($file, 'lxlabs');
+		 
+		if($result === false)
+		{
 			$error_msg = 'File \''.$file.'\' could not be created.';
 			dprint($error_msg);
-			log_log('filesys', $error_msg);
+			//log_log('filesys', $error_msg);
 			return false;
 		}
 		return true;
@@ -587,7 +605,9 @@ function lx_merge_good($arg)
 	$start = 0;
 	$transforming_func = null;
 
-	eval($sgbl->arg_getting_string);
+	$arglist = array();
+	for ($i = 0; $i < func_num_args(); $i++)
+	$arglist[] = func_get_arg($i);
 
 	//dprintr($arglist);
 
@@ -867,11 +887,12 @@ function lx_redefine_func($func)
 {
 	global $gbl, $sgbl, $login, $ghtml;
 
-	$start = 1;
-	$transforming_func = "expand_real_root";
-
-	eval($sgbl->arg_getting_string);
-
+	global $gbl, $sgbl, $login, $ghtml;
+	
+	$arglist = array();
+	for ($i = 1; $i < func_num_args(); $i++)
+	$arglist[] = expand_real_root(func_get_arg($i));
+	
 	return call_user_func_array($func, $arglist);
 }
 
@@ -1851,11 +1872,14 @@ function init_language()
 
 	include_once("htmllib/lib/commonmessagelib.php");
 
+	date_default_timezone_set('America/New_York');
 	$g_language_mes = new Language_Mes();
 	$g_language_mes->__information = $__information;
 	$g_language_mes->__emessage = $__emessage;
 	$g_language_mes->__keyword = $__keyword;
+	if(!isset($__help))  $__help = NULL;
 	$g_language_mes->__help = $__help;
+	if(!isset($__helpvar))  $__helpvar = NULL;
 	$g_language_mes->__helpvar = $__helpvar;
 	$g_language_mes->__commonhelp = $g_commonhelp;
 
@@ -1958,7 +1982,7 @@ function lx_exception_handler($e)
 function check_raw_password($class, $client, $pass)
 {
 	//return true;
-
+	
 	if (!$class || !$client || !$pass) {
 		return false;
 	}
@@ -1966,7 +1990,7 @@ function check_raw_password($class, $client, $pass)
 	$rawdb = new Sqlite(null, $class);
 	$password = $rawdb->rawquery("select password from $class where nname = '$client'");
 	$enp = $password[0]['password'];
-
+	
 	if ($enp && check_password($pass, $enp)) {
 		return true;
 	}
@@ -2060,7 +2084,7 @@ function initProgramlib($ctype = null)
 	}
 	static $var = 0;
 	$var++;
-
+	
 	$progname = $sgbl->__var_program_name;
 	lfile_put_contents($sgbl->__var_error_file, "");
 	set_exception_handler("lx_exception_handler");
@@ -2068,7 +2092,7 @@ function initProgramlib($ctype = null)
 	set_error_handler("lx_error_handler");
 
 	//setcookie("XDEBUG_SESSION", "sess");
-
+	
 	if ($var >= 2) {
 		dprint("initProgramlib called twice \n <br> ");
 	}
@@ -2085,11 +2109,12 @@ function initProgramlib($ctype = null)
 		$login->get();
 		return;
 	} else if ($ctype != "") {
+		
 		$login = new Client(null, null, $ctype, "login", "forced");
 		$login->get();
 		return;
 	}
-
+	
 	$sessobj = null;
 	if ($ghtml->frm_consumedlogin === 'true') {
 		$clientname = $_COOKIE["$progname-consumed-clientname"];
@@ -2099,6 +2124,7 @@ function initProgramlib($ctype = null)
 		$login->__session_id = $session_id;
 		$sessobj = $login->getObject('ssession');
 	} else {
+		
 		if (isset($_COOKIE["$progname-session-id"])) {
 			$clientname = $_COOKIE["$progname-clientname"];
 			$classname = $_COOKIE["$progname-classname"];
@@ -2119,7 +2145,7 @@ function initProgramlib($ctype = null)
 			}
 		}
 	}
-
+	
 	if (!$sessobj || $sessobj->dbaction === 'add') {
 		if ($ghtml->frm_ssl) {
 			$ssl = unserialize(base64_decode($ghtml->frm_ssl));
@@ -2139,7 +2165,7 @@ function initProgramlib($ctype = null)
 			$sessobj->dbaction = 'clean';
 		}
 	}
-
+	
 	//get_savedlogin($classname, $clientname);
 	//print_time('login_get', "Login Get");
 	//dprintr($login);
@@ -2158,7 +2184,7 @@ if (isset($login)) {
 		clear_all_cookie();
 		$ghtml->print_redirect_self("/login/");
 	}
-
+	
 	$gbl->c_session = $sessobj;
 
 	if ($login->getClName() !== $sessobj->parent_clname) {
@@ -2168,7 +2194,7 @@ if (isset($login)) {
 		clear_all_cookie();
 		$ghtml->print_redirect_self("/login/?frm_emessage=sessionname_not_client");
 	}
-
+	
 	$gen = $login->getObject('general')->generalmisc_b;
 
 	if (!$gen->isOn('disableipcheck') && $_SERVER['REMOTE_ADDR'] != $sessobj->ip_address) {
@@ -2187,7 +2213,7 @@ if (isset($login)) {
 			}
 		}
 	}
-
+	
 	if (intval($login->getSpecialObject('sp_specialplay')->ssession_timeout) <= 100) {
 		$login->getSpecialObject('sp_specialplay')->ssession_timeout = 100;
 		$login->setUpdateSubaction();
@@ -2198,7 +2224,7 @@ if (isset($login)) {
 	//$timeout  =  $sessobj->last_access + 4;
 	$sessobj->last_access = time();
 	$sessobj->setUpdateSubaction();
-
+	
 	if ($sessobj->auxiliary_id) {
 		$aux = new Auxiliary(null, null, $sessobj->auxiliary_id);
 		$aux->get();
@@ -2215,7 +2241,7 @@ if (isset($login)) {
 			$ghtml->print_redirect_self("/login/?frm_emessage=session_timeout");
 		}
 	}
-
+	
 	addToUtmp($sessobj, 'update');
 }
 
@@ -2641,7 +2667,9 @@ function exec_class_method($class, $func)
 	//Arg getting string is a function that needs $start to be set.
 	$start = 2;
 
-	eval($sgbl->arg_getting_string);
+	$arglist = array();
+	for ($i = $start; $i < func_num_args(); $i++)
+	$arglist[] = func_get_arg($i);
 
 	// workaround for the following php bug:
 	//   http://bugs.php.net/bug.php?id=47948

--- a/hypervm/httpdocs/index.php
+++ b/hypervm/httpdocs/index.php
@@ -13,7 +13,7 @@ function domainshow()
         $doctype = "client";
         $domainclass = "domaina";
     }
-
+    
 
     $url = "a=show";
     $url = $ghtml->getFullUrl($url);
@@ -49,6 +49,7 @@ function domainshow()
     <title><?php echo $title ?></title>
 
     <?php
+    
     print("<link rel=\"icon\" href=\"favicon.ico\" type=\"image/x-icon\">\n");
     print("<link rel=\"shortcut icon\" href=\"favicon.ico\" type=\"image/x-icon\">\n");
 
@@ -61,7 +62,7 @@ function domainshow()
         print("<FRAME name=bottomframe src='htmllib/lbin/bottom.php'>\n");
         return;
     }
-
+    
     if ($login->isDefaultSkin()) {
         $headerheight = 93;
     } else {
@@ -93,20 +94,15 @@ function domainshow()
     }
     print("</FRAMESET>\n");
     print("</FRAMESET>\n");
-
     ?>
 </head>
     <?php
 
 }
 
-function main_main()
-{
-    global $gbl, $login, $ghtml;
-    initProgram();
-    domainshow();
-}
 
 redirect_to_https();
-main_main();
+
+initProgram();
+domainshow();
 

--- a/hypervm/httpdocs/lib/client/clientlib.php
+++ b/hypervm/httpdocs/lib/client/clientlib.php
@@ -97,14 +97,20 @@ static function addform($parent, $class, $typetd = null)
 function getVpsServers($type)
 {
 	global $gbl, $sgbl, $login, $ghtml; 
-	$list = $login->getServerList('vps');
+
+	$vps_list = $login->getServerList('vps');
+
 	$outlist = null;
-	foreach($list as $l) {
-		$driverapp = $gbl->getSyncClass(null, $l, 'vps');
-		if ($driverapp === $type) {
-			$outlist[] = $l;
+	if(!empty($vps_list)) {
+		foreach($vps_list as $vps) {
+			$driverapp = $gbl->getSyncClass(NULL, $vps, 'vps');
+
+			if ($driverapp === $type) {
+				$outlist[] = $vps;
+			}
 		}
 	}
+	
 	return $outlist;
 }
 

--- a/hypervm/httpdocs/lib/pserver/pserverlib.php
+++ b/hypervm/httpdocs/lib/pserver/pserverlib.php
@@ -95,7 +95,7 @@ function createGraphList()
 	return $alist;
 }
 
-static function  createListNlist($parent)
+static function  createListNlist($parent, $class = NULL)
 {
 
 	$nlist['ostype'] = '3%';

--- a/hypervm/httpdocs/lib/vps/centralbackupserver.php
+++ b/hypervm/httpdocs/lib/vps/centralbackupserver.php
@@ -33,7 +33,7 @@ static function createListAlist($parent, $class)
 }
 
 
-static function createListNlist($parent)
+static function createListNlist($parent, $class = NULL)
 {
 	//$nlist['enable_flag'] = '5%';
 	$nlist['nname'] = '100%';

--- a/hypervm/httpdocs/lib/vps/vpslib.php
+++ b/hypervm/httpdocs/lib/vps/vpslib.php
@@ -12,7 +12,7 @@ static $__desc_nname	 = array("n", "",  "ipaddress");
 
 static function createListAddForm($parent, $class) { return false;}
 
-static function createListAlist($parent, $class)
+static function createListAlist($parent, $class = NULL)
 {
 
 	$alist[] = "a=list&c=$class";
@@ -547,7 +547,15 @@ function display($var)
 	}
 
 	if ($var === 'coma_vmipaddress_a') {
-		return getFirstFromList($this->vmipaddress_a)->nname;
+		$data = getFirstFromList($this->vmipaddress_a);
+		if(isset($data->nname))
+		{
+			return $data->nname;
+		}
+		else
+		{
+			return NULL;
+		}
 	}
 
 	if ($var === 'lmemoryusage_f') {
@@ -607,7 +615,7 @@ function perDisplay($var)
 	}
 }
 
-static function createListAlist($parent, $class)
+static function createListAlist($parent, $class = NULL)
 {
 	global $gbl, $sgbl, $login, $ghtml; 
 	$alist[] = "a=list&c=vps";
@@ -1602,9 +1610,15 @@ static function addform($parent, $class, $typetd = null)
 	$vlist['resourceplan_f'] = array('A', $nclist);
 
 	$vlist['__c_subtitle_server'] = "Server";
+	//var_dump($typetd['val']);
+	
+	// $typetd['val'] openvz or xen in clientlib.php
 	$serverlist = $parent->getVpsServers($typetd['val']);
 	if (!$serverlist) {
-		throw new lxexception("no_servers_configured_for_this_driver", '', '');
+		throw new lxexception('Server no configured for driver '. $typetd['val'] . '. You can use setdriver.php for configure a driver.
+		 For example:
+		cd /usr/local/lxlabs/hypervm/httpdocs;
+		lphp.exe ../bin/common/setdriver.php --server=localhost --class=vps --driver='. $typetd['val'] . '', '', '');
 	}
 
 	$sinfo = pserver::createServerInfo($serverlist, "vps");
@@ -2278,7 +2292,7 @@ function getHardProperty()
 	$this->coma_vmipaddress_a = implode(",", get_namelist_from_objectlist($this->vmipaddress_a));
 }
 
-function createShowAlistConfig(&$alist)
+function createShowAlistConfig(&$alist, $subaction = null)
 {
 	global $gbl, $sgbl, $login, $ghtml; 
 	$alist['__title_main'] = $login->getKeywordUc('resource');
@@ -2385,7 +2399,15 @@ function createShowInfoList($subaction)
 		}
 	}
 
-	$ilist['IP'] = substr(implode(",", get_namelist_from_objectlist($this->vmipaddress_a)), 0, 17);
+	$name_list = get_namelist_from_objectlist($this->vmipaddress_a);
+	
+	if(!empty($name_list)) {
+		$ilist['IP'] = substr(implode(",", $name_list), 0, 17);
+	}
+	else {
+		$ilist['IP'] = NULL;
+	}
+	
 	$this->getLastLogin($ilist);
 	return $ilist;
 }

--- a/hypervm/src/program-backend.c
+++ b/hypervm/src/program-backend.c
@@ -99,7 +99,6 @@
  *
  */
 
-
 #include "program-backend.h"
 
 int run_php_prog_ssl(SSL *ssl, int sock)
@@ -141,7 +140,8 @@ int run_php_prog_ssl(SSL *ssl, int sock)
 		}
 	}
 
-	printf("Input %d %s\n", strlen(data), data);
+	/* ISO C90 uses unsigned long for size_t (%lu). For ISO C99 %zd is used as signed decimal portable for data (size_t) */
+	printf("Input %lu %s\n", (unsigned long) strlen(data), data);
 	bzero(buf, sizeof(buf));
 	/* printf ("Received %d chars:'%s'\n", err, buf); */
 
@@ -374,10 +374,11 @@ int accept_and(int listen_sock)
 {
 	int sock;
 	struct sockaddr_in sa_cli;
-	size_t client_len;
-	client_len = sizeof(sa_cli);
+	socklen_t client_len;
+	client_len = sizeof(struct sockaddr_in);
+
 	/* Socket for a TCP/IP connection is created */
-	sock = accept(listen_sock, (struct sockaddr*)&sa_cli, &client_len);
+	sock = accept(listen_sock, (struct sockaddr*)&sa_cli, (socklen_t *) &client_len);
 	/* printf ("Connection from %lx, port %x\n", sa_cli.sin_addr.s_addr, sa_cli.sin_port); */
 	return sock;
 }


### PR DESCRIPTION
This is a enhancement of code that it is consist on:
- Full support of lxphp based on PHP 5.3  (Tested with PHP 5.3.8, note: some php.ini changes on .rpm are needed)
  I based my test with the RPM builded http://quijost.com/lxcenter/lxphp-5.3.8-0lxcenter1.i386.rpm
- Fix a lot warnings of missing params (by inherit of parent class), empty index or foreach iterations and NULL check values.
- Backend C support for ISO90 on OpenVZ kernels
- Messages improments for warnings and exceptions for give more data to the user.

See diff changes for full details.
