### PR TITLE
Driver openvzlib rhel6 support

### DIFF
--- a/hypervm/httpdocs/lib/vps/driver/vps__openvzlib.phps
+++ b/hypervm/httpdocs/lib/vps/driver/vps__openvzlib.phps
@@ -204,7 +204,13 @@ class vps__openvz extends Lxdriverclass {
 		$path = "/proc/user_beancounters";
 		
 		$data = `/usr/sbin/vzctl exec $vpsid cat /proc/user_beancounters`;
-	
+
+                if (self::checkIfRHEL6Kernel()) {
+                    $beancounter = "physpages";
+                } else {
+                    $beancounter = "privvmpages";
+                }
+                
 		$res = explode("\n", $data);
 		$match = true;
 		foreach($res as $r) {
@@ -214,7 +220,7 @@ class vps__openvz extends Lxdriverclass {
 			}
 		*/
 	
-			if ($match && csa($r, "privvmpages")) {
+			if ($match && csa($r, $beancounter)) {
 				break;
 			}
 		}

--- a/hypervm/httpdocs/lib/vps/driver/vps__openvzlib.phps
+++ b/hypervm/httpdocs/lib/vps/driver/vps__openvzlib.phps
@@ -583,10 +583,13 @@ class vps__openvz extends Lxdriverclass {
 		} else {
 			$memory = $this->main->priv->memory_usage * 256;
 		}
-	
-		lxshell_return("/usr/sbin/vzctl", "set", $this->main->vpsid, "--save", "--privvmpages", $memory);
-		lxshell_return("/usr/sbin/vzctl", "set", $this->main->vpsid, "--save", "--meminfo", "pages:$memory");
-	}
+
+                if (!self::checkIfRHEL6Kernel()) {
+        		lxshell_return("/usr/sbin/vzctl", "set", $this->main->vpsid, "--save", "--privvmpages", $memory);
+                }
+
+                lxshell_return("/usr/sbin/vzctl", "set", $this->main->vpsid, "--save", "--meminfo", "pages:$memory");
+        }
 
 	function do_backup()
 	{
@@ -678,10 +681,15 @@ class vps__openvz extends Lxdriverclass {
 			$memory = $this->main->priv->guarmem_usage;
 		}
 	
-		lxshell_return("/usr/sbin/vzctl", "set", $this->main->vpsid, "--save", "--vmguarpages", "{$memory}M:2147483647");
-		lxshell_return("/usr/sbin/vzctl", "set", $this->main->vpsid, "--save", "--oomguarpages", "{$memory}M:2147483647");
-		lxshell_return("/usr/sbin/vzctl", "set", $this->main->vpsid, "--save", "--shmpages", "{$memory}M:{$memory}M");
-		lxshell_return("/usr/sbin/vzctl", "set", $this->main->vpsid, "--save", "--physpages", "0:2147483647");
+                if (self::checkIfRHEL6Kernel()) {
+                   lxshell_return("/usr/sbin/vzctl", "set", $this->main->vpsid, "--save", "--physpages", "0:{$memory}M");
+                } else {
+                    lxshell_return("/usr/sbin/vzctl", "set", $this->main->vpsid, "--save", "--vmguarpages", "{$memory}M:2147483647");
+                    lxshell_return("/usr/sbin/vzctl", "set", $this->main->vpsid, "--save", "--oomguarpages", "{$memory}M:2147483647");
+                    lxshell_return("/usr/sbin/vzctl", "set", $this->main->vpsid, "--save", "--shmpages", "{$memory}M:{$memory}M");
+                    lxshell_return("/usr/sbin/vzctl", "set", $this->main->vpsid, "--save", "--physpages", "0:2147483647");
+                }
+                
 		$tcp = round(($memory * 1024)/5, 0);
 		$process = $this->main->priv->process_usage;
 		if (is_unlimited($process) || $process > 5555) {
@@ -1623,4 +1631,22 @@ class vps__openvz extends Lxdriverclass {
 		}
 		return $res;
 	}
+        
+        static function checkIfRHEL6Kernel()
+        {
+ 
+            $proc_version = file_get_contents('/proc/version');
+
+            if (preg_match("/2.6.32-/", $proc_version)) {
+
+                return true;
+                
+            } else {
+                
+                return false;
+                
+            }
+            
+        }
+        
 }


### PR DESCRIPTION
This is a first set ot enhancements for OpenVZ VPS driver for work with latest RHEL6 OpenVZ kernel. I added there a one extra function called checkIfRHEL6Kernel() which read /proc/version file and match the kernel version number. 
When the 2.6.32 kernel is detected then driver would set a proper value for physpages. 
The same happened in vpsInfo() function but instead of setting something we are reading a different value from /proc/user_beancounters. Current and max memory is provided by physpages.
