### PR TITLE
Update openvz.repo into the latest one

### DIFF
--- a/hypervm/file/openvz.repo
+++ b/hypervm/file/openvz.repo
@@ -1,68 +1,64 @@
 [openvz-utils]
-name=OpenVZ utilities
+name=OpenVZ user-space utilities
 #baseurl=http://download.openvz.org/current/
 mirrorlist=http://download.openvz.org/mirrors-current
 enabled=1
 gpgcheck=1
 gpgkey=http://download.openvz.org/RPM-GPG-Key-OpenVZ
 
-# In addition to openvz-utils repo, you have to enable one the the
-# kernel repositories below. In the stock config, openvz-kernel-rhel5
-# is enabled; you might want to change this.
+# In addition to the above repo, you have to enable at least one the the
+# kernel repositories below. By default, openvz-kernel-rhel6 is enabled;
+# you might want to change this.
 
-[openvz-kernel-2.6.22]
-name=OpenVZ 2.6.22 kernel
-#baseurl=http://download.openvz.org/kernel/branches/2.6.20/current
-mirrorlist=http://download.openvz.org/kernel/mirrors-2.6.22
+
+## RHEL6-based OpenVZ kernels
+
+[openvz-kernel-rhel6]
+name=OpenVZ RHEL6-based stable kernels
+#baseurl=http://download.openvz.org/kernel/branches/rhel6-2.6.32/current/
+mirrorlist=http://download.openvz.org/kernel/mirrors-rhel6-2.6.32
+enabled=1
+gpgcheck=1
+gpgkey=http://download.openvz.org/RPM-GPG-Key-OpenVZ
+exclude=vzkernel-firmware
+
+# Feel free to enable testing repo if you want newer testing kernels
+[openvz-kernel-rhel6-testing]
+name=OpenVZ RHEL6-based testing kernels
+#baseurl=http://download.openvz.org/kernel/branches/rhel6-2.6.32-testing/current/
+mirrorlist=http://download.openvz.org/kernel/mirrors-rhel6-2.6.32-testing
+enabled=0
+gpgcheck=1
+gpgkey=http://download.openvz.org/RPM-GPG-Key-OpenVZ
+exclude=vzkernel-firmware
+
+# You might need to enable debuginfo, if asked by developers
+[openvz-kernel-rhel6-debuginfo]
+name=OpenVZ RHEL6-based testing kernel debuginfo rpms
+baseurl=http://download.openvz.org/kernel/branches/rhel6-2.6.32-testing/debuginfo
 enabled=0
 gpgcheck=1
 gpgkey=http://download.openvz.org/RPM-GPG-Key-OpenVZ
 
-[openvz-kernel-2.6.20]
-name=OpenVZ 2.6.20 kernel
-#baseurl=http://download.openvz.org/kernel/branches/2.6.20/current
-mirrorlist=http://download.openvz.org/kernel/mirrors-2.6.20
-enabled=0
-gpgcheck=1
-gpgkey=http://download.openvz.org/RPM-GPG-Key-OpenVZ
+
+## RHEL5-based OpenVZ kernels. Come on, switch to RHEL6 already!
 
 [openvz-kernel-rhel5]
 name=OpenVZ RHEL5-based kernel
 #baseurl=http://download.openvz.org/kernel/branches/rhel5-2.6.18/current/
 mirrorlist=http://download.openvz.org/kernel/mirrors-rhel5-2.6.18
-enabled=1
-gpgcheck=1
-gpgkey=http://download.openvz.org/RPM-GPG-Key-OpenVZ
-
-[openvz-kernel-2.6.18]
-name=OpenVZ 2.6.18 kernel
-#baseurl=http://download.openvz.org/kernel/branches/2.6.18/current
-mirrorlist=http://download.openvz.org/kernel/mirrors-2.6.18
 enabled=0
 gpgcheck=1
 gpgkey=http://download.openvz.org/RPM-GPG-Key-OpenVZ
 
-[openvz-kernel-2.6.16]
-name=OpenVZ 2.6.16 kernel
-#baseurl=http://download.openvz.org/kernel/branches/2.6.16/current
-mirrorlist=http://download.openvz.org/kernel/mirrors-2.6.16
+[openvz-kernel-rhel5-testing]
+name=OpenVZ RHEL5-based testing kernel
+#baseurl=http://download.openvz.org/kernel/branches/rhel5-2.6.18-testing/current/
+mirrorlist=http://download.openvz.org/kernel/mirrors-rhel5-2.6.18-testing
 enabled=0
 gpgcheck=1
 gpgkey=http://download.openvz.org/RPM-GPG-Key-OpenVZ
 
-[openvz-kernel-rhel4]
-name=OpenVZ RHEL4-based kernel
-#baseurl=http://download.openvz.org/kernel/branches/rhel4-2.6.9/current/
-mirrorlist=http://download.openvz.org/kernel/mirrors-rhel4-2.6.9
-enabled=0
-gpgcheck=1
-gpgkey=http://download.openvz.org/RPM-GPG-Key-OpenVZ
-
-[openvz-kernel-2.6.8]
-name=OpenVZ 2.6.8 kernel
-#baseurl=http://download.openvz.org/kernel/branches/2.6.8/current
-mirrorlist=http://download.openvz.org/kernel/mirrors-2.6.8
-enabled=0
-gpgcheck=1
-gpgkey=http://download.openvz.org/RPM-GPG-Key-OpenVZ
+## Development branches
+# ....none at this point
 


### PR DESCRIPTION
This is an update of openvz.repo file into the latest one. Without it the OpenVZ kernel won't install on RHEL6 / CentOS6
