### PR TITLE
Fixing xen ip stack seperating ipv4 and ipv6

### DIFF
--- a/hypervm/httpdocs/lib/vps/driver/vps__xenlib.php
+++ b/hypervm/httpdocs/lib/vps/driver/vps__xenlib.php
@@ -2018,6 +2018,22 @@ class vps__xen extends Lxdriverclass {
 	
 		$iplist = implode(" ", $iplist);
 	
+		$iplistnew  = preg_split('/ /', $iplist,-1,PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+    		//counting the elements of the array aka ip
+		 $ipcnt = count($iplistnew);
+    
+    		for($i = 0; $i < $ipcnt ; $i++) {
+			 if (isIPV6($iplistnew[$i])) {
+			      $iplist6new[$i] = $iplistnew[$i];
+        		      $ip6list= implode(" ",$iplist6new);
+        	}elseif (!isIPV6($iplistnew[$i])){            
+                		 $iplist4new[$i] = $iplistnew[$i];
+                 		 $ip4list = implode(" ",$iplist4new);
+        	}else { 
+        			 throw new lxException("The Iplist does not contain any values");                 
+        		 }
+    		}
+	
 		$ipadd = $result['ADD_IP'];
 		$sethostname = $result['SET_HOSTNAME'];
 		$setuserpass = $result['SET_USERPASS'];


### PR DESCRIPTION
This fix is for xen to properly handle ipv6 and ipv4 addresses by seperating them at the list level and assign them properly to the guest os systems 

Note the xen scripts needs to be fixed after this commit!
